### PR TITLE
Add --no-cache flag for Docker build cache clearing

### DIFF
--- a/yolo
+++ b/yolo
@@ -13,6 +13,7 @@ usage() {
     echo "Options:"
     echo "  -h, --help           Show this help message"
     echo "  --build              Build the container image without running it"
+    echo "  --no-cache           Clear Docker cache during build (requires --build)"
     echo "  --apt PACKAGES...    Add apt packages (requires --build)"
     echo "  --npm PACKAGES...    Add npm packages (requires --build)"
     echo ""
@@ -24,6 +25,7 @@ usage() {
     echo "Examples:"
     echo "  $SCRIPT_NAME                              # Run existing container (requires prior build)"
     echo "  $SCRIPT_NAME --build                      # Build image with defaults"
+    echo "  $SCRIPT_NAME --build --no-cache           # Build with cleared cache"
     echo "  $SCRIPT_NAME --build --apt golang         # Build with golang"
     echo "  $SCRIPT_NAME --build --npm typescript     # Build with TypeScript"
     echo "  $SCRIPT_NAME --build --apt clojure leiningen  # Build with multiple apt packages"
@@ -63,7 +65,10 @@ check_requirements() {
 }
 
 build_image() {
-    # Parse arguments - split on "---" separator
+    # Parse arguments - first argument is no_cache flag, then split on "---" separator
+    local no_cache="$1"
+    shift
+
     local apt_packages=()
     local npm_packages=()
     local current_array="apt"
@@ -323,7 +328,14 @@ ENTRYPOINT ["/entrypoint.sh"]
 EOF
 
     # Build the image
-    if docker build -t "$IMAGE_NAME" "$build_dir"; then
+    local build_args=("-t" "$IMAGE_NAME")
+    if [[ "$no_cache" == "true" ]]; then
+        echo "Building with --no-cache flag (cleared cache)..."
+        build_args+=("--no-cache")
+    fi
+    build_args+=("$build_dir")
+
+    if docker build "${build_args[@]}"; then
         echo "Container image built successfully"
     else
         echo "Error: Failed to build container image"
@@ -412,6 +424,7 @@ run_container() {
 main() {
     local force_build=false
     local build_only=false
+    local no_cache=false
     local apt_packages=()
     local npm_packages=()
 
@@ -424,6 +437,10 @@ main() {
             --build)
                 force_build=true
                 build_only=true
+                shift
+                ;;
+            --no-cache)
+                no_cache=true
                 shift
                 ;;
             --apt)
@@ -471,9 +488,16 @@ main() {
         fi
     fi
 
+    # Validate that --no-cache requires --build
+    if [[ "$no_cache" == true ]] && [[ "$force_build" != true ]]; then
+        echo "Error: --no-cache requires --build to be specified"
+        echo "Example: $SCRIPT_NAME --build --no-cache"
+        exit 1
+    fi
+
     # Build image if --build is specified
     if [[ "$force_build" == true ]]; then
-        build_image ${apt_packages[@]+"${apt_packages[@]}"} "---" ${npm_packages[@]+"${npm_packages[@]}"}
+        build_image "$no_cache" ${apt_packages[@]+"${apt_packages[@]}"} "---" ${npm_packages[@]+"${npm_packages[@]}"}
     fi
 
     # Only run container if not in build-only mode


### PR DESCRIPTION
Enables rebuilding the container with cleared Docker cache using ./yolo --build --no-cache for fresh builds when needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)